### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/578/148/3/1125781483.geojson
+++ b/data/112/578/148/3/1125781483.geojson
@@ -31,6 +31,9 @@
     "name:arg_x_preferred":[
         "Mata-Utu"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u062a\u0627 \u0627\u0648\u062a\u0648"
+    ],
     "name:ast_x_preferred":[
         "Mata-Utu"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u0442\u0430-\u0423\u0442\u0443"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u0442\u0430-\u0423\u0442\u0443"
     ],
     "name:bos_x_preferred":[
         "Mata-Utu"
@@ -78,6 +84,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03ac\u03c4\u03b1-\u039f\u03cd\u03c4\u03bf\u03c5"
+    ],
+    "name:ell_x_variant":[
+        "\u039c\u03b1\u03c4\u03ac-\u039f\u03c5\u03c4\u03bf\u03cd"
     ],
     "name:eng_x_preferred":[
         "Mata-Utu"
@@ -129,6 +138,9 @@
     ],
     "name:hif_x_preferred":[
         "Mata-Utu"
+    ],
+    "name:hin_x_preferred":[
+        "\u092e\u093e\u0924\u093e \u0909\u0924\u0941"
     ],
     "name:hrv_x_preferred":[
         "Mata-Utu"
@@ -253,6 +265,9 @@
     "name:prg_x_preferred":[
         "Mata-Utu"
     ],
+    "name:pus_x_preferred":[
+        "\u0645\u0627\u062a\u0627 \u0627\u0648\u062a\u0648"
+    ],
     "name:rgn_x_preferred":[
         "Mata-Utu"
     ],
@@ -295,6 +310,9 @@
     "name:tam_x_preferred":[
         "\u0bae\u0bbe\u0ba4\u0bbe-\u0b89\u0ba4\u0bc1"
     ],
+    "name:tgk_x_preferred":[
+        "\u041c\u0430\u0442\u0430-\u0423\u0442\u0443"
+    ],
     "name:tha_x_preferred":[
         "\u0e21\u0e32\u0e15\u0e32-\u0e2d\u0e39\u0e15\u0e39"
     ],
@@ -333,6 +351,9 @@
     ],
     "name:wol_x_preferred":[
         "Mata-Utu"
+    ],
+    "name:wuu_x_preferred":[
+        "\u9a6c\u5854\u4e4c\u56fe"
     ],
     "name:xmf_x_preferred":[
         "\u10db\u10d0\u10e2\u10d0-\u10e3\u10e2\u10e3"
@@ -382,7 +403,7 @@
         }
     ],
     "wof:id":1125781483,
-    "wof:lastmodified":1566652693,
+    "wof:lastmodified":1690921648,
     "wof:name":"Mata-Utu",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",

--- a/data/890/422/953/890422953.geojson
+++ b/data/890/422/953/890422953.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Vele"
+    ],
+    "name:ceb_x_preferred":[
+        "Vel\u00e9"
+    ],
     "name:deu_x_preferred":[
         "Vele"
     ],
@@ -41,6 +47,18 @@
         "\u30f4\u30eb"
     ],
     "name:nld_x_preferred":[
+        "Vele"
+    ],
+    "name:por_x_preferred":[
+        "Vele"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u0435\u043b\u0435"
+    ],
+    "name:spa_x_preferred":[
+        "Vele"
+    ],
+    "name:wls_x_preferred":[
         "Vele"
     ],
     "qs:name":"Vel\u00e9",
@@ -77,7 +95,7 @@
         }
     ],
     "wof:id":890422953,
-    "wof:lastmodified":1566652691,
+    "wof:lastmodified":1690921641,
     "wof:name":"Vel\u00e9",
     "wof:parent_id":85680905,
     "wof:placetype":"locality",

--- a/data/890/422/955/890422955.geojson
+++ b/data/890/422/955/890422955.geojson
@@ -37,7 +37,13 @@
     "name:pol_x_preferred":[
         "Vaitupu"
     ],
+    "name:rus_x_preferred":[
+        "\u0412\u0430\u0438\u0442\u0443\u043f\u0443"
+    ],
     "name:swe_x_preferred":[
+        "Vaitupu"
+    ],
+    "name:wls_x_preferred":[
         "Vaitupu"
     ],
     "name:zho_x_preferred":[
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":890422955,
-    "wof:lastmodified":1566652691,
+    "wof:lastmodified":1690921641,
     "wof:name":"Vaitupu",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",

--- a/data/890/434/961/890434961.geojson
+++ b/data/890/434/961/890434961.geojson
@@ -43,6 +43,9 @@
     "name:nld_x_preferred":[
         "Vailala"
     ],
+    "name:rus_x_preferred":[
+        "\u0412\u0430\u0438\u043b\u0430\u043b\u0430"
+    ],
     "qs:name":"Vailala",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890434961,
-    "wof:lastmodified":1566652691,
+    "wof:lastmodified":1690921644,
     "wof:name":"Vailala",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/434/963/890434963.geojson
+++ b/data/890/434/963/890434963.geojson
@@ -43,6 +43,12 @@
     "name:pol_x_preferred":[
         "Utufua"
     ],
+    "name:rus_x_preferred":[
+        "\u0423\u0442\u0443\u0444\u0443\u0430"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0423\u0442\u0443\u0444\u0443\u0430"
+    ],
     "qs:name":"Utufua",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -70,7 +76,7 @@
         }
     ],
     "wof:id":890434963,
-    "wof:lastmodified":1566652691,
+    "wof:lastmodified":1690921643,
     "wof:name":"Utufua",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/434/979/890434979.geojson
+++ b/data/890/434/979/890434979.geojson
@@ -25,7 +25,16 @@
     "name:eng_x_preferred":[
         "Liku"
     ],
+    "name:fra_x_preferred":[
+        "Liku"
+    ],
     "name:nld_x_preferred":[
+        "Liku"
+    ],
+    "name:rus_x_preferred":[
+        "\u041b\u0438\u043a\u0443"
+    ],
+    "name:wls_x_preferred":[
         "Liku"
     ],
     "qs:name":"Liku",
@@ -58,7 +67,7 @@
         }
     ],
     "wof:id":890434979,
-    "wof:lastmodified":1566652691,
+    "wof:lastmodified":1690921644,
     "wof:name":"Liku",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",

--- a/data/890/434/981/890434981.geojson
+++ b/data/890/434/981/890434981.geojson
@@ -40,6 +40,15 @@
     "name:nld_x_preferred":[
         "Kolopopo"
     ],
+    "name:pol_x_preferred":[
+        "Kolopopo"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u043b\u043e\u043f\u043e\u043f\u043e"
+    ],
+    "name:uzb_x_preferred":[
+        "Kolopopo"
+    ],
     "qs:name":"Kolopopo",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -67,7 +76,7 @@
         }
     ],
     "wof:id":890434981,
-    "wof:lastmodified":1566652692,
+    "wof:lastmodified":1690921645,
     "wof:name":"Kolopopo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/434/991/890434991.geojson
+++ b/data/890/434/991/890434991.geojson
@@ -34,6 +34,12 @@
     "name:nld_x_preferred":[
         "Kolia"
     ],
+    "name:pol_x_preferred":[
+        "Kolia"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u043b\u0438\u0430"
+    ],
     "qs:name":"Kolia",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":890434991,
-    "wof:lastmodified":1566652691,
+    "wof:lastmodified":1690921643,
     "wof:name":"Kolia",
     "wof:parent_id":85680905,
     "wof:placetype":"locality",

--- a/data/890/435/013/890435013.geojson
+++ b/data/890/435/013/890435013.geojson
@@ -37,17 +37,26 @@
     "name:ita_x_preferred":[
         "Halalo"
     ],
+    "name:mkd_x_preferred":[
+        "\u0425\u0430\u043b\u0430\u043b\u043e"
+    ],
     "name:nld_x_preferred":[
         "Halalo"
     ],
     "name:pol_x_preferred":[
         "Halalo"
     ],
+    "name:ukr_x_preferred":[
+        "\u0425\u0430\u043b\u0430\u043b\u043e"
+    ],
     "name:und_x_variant":[
         "Ha\u2019alalo"
     ],
     "name:urd_x_preferred":[
         "\u06c1\u0627\u0622\u062a\u0648\u0641\u0648"
+    ],
+    "name:uzb_x_preferred":[
+        "Halalo"
     ],
     "qs:name":"Halalo",
     "qs:photos_9r":0,
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":890435013,
-    "wof:lastmodified":1566652692,
+    "wof:lastmodified":1690921646,
     "wof:name":"Halalo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/015/890435015.geojson
+++ b/data/890/435/015/890435015.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Ha'atofo"
+    ],
     "name:deu_x_preferred":[
         "Ha\u02bbatofo"
     ],
@@ -34,11 +37,20 @@
     "name:nld_x_preferred":[
         "Ha'atofo"
     ],
+    "name:pol_x_preferred":[
+        "Ha\u02bbatofo"
+    ],
     "name:por_x_preferred":[
+        "Ha'atofo"
+    ],
+    "name:spa_x_preferred":[
         "Ha'atofo"
     ],
     "name:urd_x_preferred":[
         "\u06c1\u0627\u0622\u062a\u0648\u0641\u0648"
+    ],
+    "name:wls_x_preferred":[
+        "Ha'atofo"
     ],
     "qs:name":"Haatofo",
     "qs:photos_9r":0,
@@ -70,7 +82,7 @@
         }
     ],
     "wof:id":890435015,
-    "wof:lastmodified":1566652692,
+    "wof:lastmodified":1690921646,
     "wof:name":"Haatofo",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",

--- a/data/890/435/019/890435019.geojson
+++ b/data/890/435/019/890435019.geojson
@@ -37,6 +37,12 @@
     "name:nld_x_preferred":[
         "Gahi"
     ],
+    "name:pol_x_preferred":[
+        "Gahi"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0430\u0445\u0438"
+    ],
     "qs:name":"Gahi",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -67,7 +73,7 @@
         }
     ],
     "wof:id":890435019,
-    "wof:lastmodified":1566652693,
+    "wof:lastmodified":1690921647,
     "wof:name":"Gahi",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",

--- a/data/890/435/021/890435021.geojson
+++ b/data/890/435/021/890435021.geojson
@@ -46,6 +46,12 @@
     "name:urd_x_preferred":[
         "\u0641\u0627\u0644\u0627\u0644\u06cc"
     ],
+    "name:uzb_x_preferred":[
+        "Falaleu"
+    ],
+    "name:wls_x_preferred":[
+        "Falaleu"
+    ],
     "qs:name":"Falaleu",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890435021,
-    "wof:lastmodified":1566652693,
+    "wof:lastmodified":1690921648,
     "wof:name":"Falaleu",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",

--- a/data/890/435/063/890435063.geojson
+++ b/data/890/435/063/890435063.geojson
@@ -43,8 +43,17 @@
     "name:pol_x_preferred":[
         "Alele"
     ],
+    "name:rus_x_preferred":[
+        "\u0410\u043b\u0435\u043b\u0435"
+    ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u06cc\u0644\u06d2"
+    ],
+    "name:uzb_x_preferred":[
+        "Alele"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u840a\u840a"
     ],
     "qs:name":"Alele",
     "qs:photos_9r":0,
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":890435063,
-    "wof:lastmodified":1566652692,
+    "wof:lastmodified":1690921647,
     "wof:name":"Alele",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",

--- a/data/890/455/929/890455929.geojson
+++ b/data/890/455/929/890455929.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0627\u0647\u0648\u0627"
+    ],
     "name:aze_x_preferred":[
         "Ahoa"
     ],
@@ -47,6 +50,12 @@
         "Ahoa"
     ],
     "name:pol_x_preferred":[
+        "Ahoa"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0445\u043e\u0430"
+    ],
+    "name:uzb_x_preferred":[
         "Ahoa"
     ],
     "qs:name":"Ahoa",
@@ -88,7 +97,7 @@
         }
     ],
     "wof:id":890455929,
-    "wof:lastmodified":1566652691,
+    "wof:lastmodified":1690921642,
     "wof:name":"Ahoa",
     "wof:parent_id":85680901,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.