### PR TITLE
wf concordances, placetype local, and more

### DIFF
--- a/data/856/808/97/85680897.geojson
+++ b/data/856/808/97/85680897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002826,
-    "geom:area_square_m":33860748.063337,
+    "geom:area_square_m":33860838.865303,
     "geom:bbox":"-178.18574,-14.313148,-178.126551,-14.232599",
     "geom:latitude":-14.270411,
     "geom:longitude":-178.155263,
@@ -423,13 +423,15 @@
         "gn:id":4034776,
         "gp:id":24549914,
         "hasc:id":"WF.SI",
+        "iso:code":"WF-SG",
         "iso:id":"WF-SG",
         "qs_pg:id":59706,
         "wd:id":"Q2554877",
         "wk:page":"Sigave"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WF",
-    "wof:geomhash":"83cd50e892c543a0a084b459142cbd4c",
+    "wof:geomhash":"b217bb7d5c4dc436cefce74e9e1e7da5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -446,7 +448,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636504676,
+    "wof:lastmodified":1695884956,
     "wof:name":"Sigave",
     "wof:parent_id":85632585,
     "wof:placetype":"region",

--- a/data/856/809/01/85680901.geojson
+++ b/data/856/809/01/85680901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00704,
-    "geom:area_square_m":84718656.008703,
+    "geom:area_square_m":84718883.152113,
     "geom:bbox":"-176.253784,-13.389584,-176.125473,-13.179639",
     "geom:latitude":-13.284514,
     "geom:longitude":-176.205855,
@@ -137,14 +137,16 @@
         "gn:id":4034759,
         "gp:id":24549911,
         "hasc:id":"WF.UV",
+        "iso:code":"WF-UV",
         "iso:id":"WF-UV",
         "qs_pg:id":1237232
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"962bec2a693e0a9b8740d6ee61d73a24",
+    "wof:geomhash":"a511de7cc20ae4aebb3446d35f8d55f8",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -159,7 +161,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636504676,
+    "wof:lastmodified":1695884956,
     "wof:name":"`Uvea",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/809/05/85680905.geojson
+++ b/data/856/809/05/85680905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004991,
-    "geom:area_square_m":59793769.814877,
+    "geom:area_square_m":59793769.81487,
     "geom:bbox":"-178.137085641,-14.3789201798,-177.976714648,-14.2555468585",
     "geom:latitude":-14.325937,
     "geom:longitude":-178.064165,
@@ -176,11 +176,13 @@
         "gn:id":4034884,
         "gp:id":24549913,
         "hasc:id":"WF.AL",
+        "iso:code":"WF-AL",
         "iso:id":"WF-AL",
         "qs_pg:id":1191251
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WF",
-    "wof:geomhash":"486d4a27062794d3ec9bb5ef75d4536c",
+    "wof:geomhash":"89dbf4cd673c17d8b3b82732c7932d0a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -197,7 +199,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566652688,
+    "wof:lastmodified":1695884327,
     "wof:name":"Alo",
     "wof:parent_id":85632585,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.